### PR TITLE
TST: cleanup seemingly unused branch

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,3 +1,4 @@
+import os
 import re
 import subprocess
 import sys
@@ -139,6 +140,8 @@ class TestCPythonFeatureSet:
             env_dict["PYTHON_GIL"] = env.GIL
         if env.JIT is not None:
             env_dict["PYTHON_JIT"] = env.JIT
+
+        env_dict["COVERAGE_PROCESS_START"] = os.getenv("COVERAGE_PROCESS_START")
 
         xoptions = [f"-X{opt}" for opt in settings.xoptions]
         cp = subprocess.run(


### PR DESCRIPTION
Reading coverage's patch=subprocess' documentation again, I think I originally set this up upon misunderstanding the following sentence

> If an exec*e or spawn*e function is used, the new environment must copy over the COVERAGE_PROCESS_START environment variable.
